### PR TITLE
feat(llm/agent): Parallel combinator + tool-arg JSON repair + context…

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -41,7 +41,7 @@ cd contrib/gorm && go test ./...
 | [`contrib/natsjs`](natsjs) | `pkg/mq` 的 NATS **JetStream** 绑定(持久化、at-least-once、重投、断线续) | nats.go/jetstream |
 | [`contrib/kafka`](kafka) | `pkg/mq` 的 Kafka broker 绑定(consumer group;at-least-once,提交后确认) | segmentio/kafka-go |
 | [`contrib/elasticsearch`](elasticsearch) | Elasticsearch 集成:健康 / 搜索 / 写入,暴露原始 JSON | go-elasticsearch/v8 |
-| [`contrib/llm`](llm) | provider 无关 LLM 客户端:对话/流式/embedding/**工具调用** + Fallback/Retry/Metered/**Guard 护栏** + 多厂商(OpenAI 兼容 / Anthropic / **AWS Bedrock**)+ 薄 **agent 循环**(`llm/agent`,含审批/流式事件/Steer/Hooks + 统一 Agent 接口/**Planner**/**Team 移交**/**BestOfN**/**VerifyLoop** 编排)+ **会话记忆** + **Agent Skills** | 无(纯 stdlib) |
+| [`contrib/llm`](llm) | provider 无关 LLM 客户端:对话/流式/embedding/**工具调用** + Fallback/Retry/Metered/**Guard 护栏** + 多厂商(OpenAI 兼容 / Anthropic / **AWS Bedrock**)+ 薄 **agent 循环**(`llm/agent`,含审批/流式事件/Steer/Hooks + 统一 Agent 接口/**Planner**/**Team 移交**/**Parallel 并发**/**BestOfN**/**VerifyLoop** 编排 + 工具参数 **JSON 容错**/运行内**上下文压缩**/消息合并)+ **会话记忆** + **Agent Skills** | 无(纯 stdlib) |
 | [`contrib/llmsession`](llmsession) | `llm/agent/session.Store` 的 SQLite / Redis 实现 | modernc.org/sqlite、go-redis |
 | [`contrib/vector`](vector) | 向量存储 / RAG 语义检索:Store 接口 + 内存实现,配 llm 搭 RAG | 无(纯 stdlib) |
 | [`contrib/memoryvector`](memoryvector) | 胶水:Embedder + vector → `llm/agent/memory.Store`(语义长期记忆) | llm + vector |

--- a/contrib/llm/README.md
+++ b/contrib/llm/README.md
@@ -146,7 +146,7 @@ resp, _ = chain.Run(ctx, req)
 
 ### 统一 Agent 接口 + 规划 / 团队 / 策略包装
 
-`Runner` / `Chain` / `Team` / `BestOfN` / `VerifyLoop` 都实现同一个 **`Agent`** 契约,可互相嵌套
+`Runner` / `Chain` / `Team` / `Parallel` / `BestOfN` / `VerifyLoop` 都实现同一个 **`Agent`** 契约,可互相嵌套
 (`AgentAsTool`、`Chain` 步骤、`Team` 成员都收 `Agent`,不再局限于 `*Runner`):
 
 ```go
@@ -154,7 +154,7 @@ type Agent interface {
     Run(ctx context.Context, req llm.Request) (*llm.Response, error)
     Info() Info                     // Name/Description/暴露的工具声明
 }
-type StreamAgent interface {         // Runner / Chain / Team 实现,可推事件
+type StreamAgent interface {         // Runner / Chain / Team / Parallel 实现,可推事件
     Agent
     RunStream(ctx context.Context, req llm.Request) <-chan Event
 }
@@ -197,11 +197,47 @@ loop := &agent.VerifyLoop{Agent: best, MaxRounds: 3,   // 包装器可任意嵌�
 resp, _ := loop.Run(ctx, req)
 ```
 
+**`Parallel`(并发扇出 + 合并)**:把**不同的** Agent 并发跑同一 Request,再用可插拔 `Combiner` 合并
+——补齐了组合家族里「并发」这一维度(`Chain` 串行、`Team` 路由、`BestOfN` 同 Agent 跑 N 次、
+`Parallel` 不同 Agent 并发)。`Combine` 为 nil 用 `ConcatCombiner`(按序拼接);任一分支失败不影响其余,
+全失败才报错。它实现 `StreamAgent`(透传各分支中间事件、仅产出一条合并后的终态),可再被 `Chain` 嵌套
+(如「并发调研 → 单 agent 汇总」= `Chain{Parallel, summarizer}`)。
+
+```go
+p := &agent.Parallel{Agents: []agent.Agent{legal, finance, tech}} // 默认拼接
+// 或注入自定义合并:投票 / 取最优 / 再交给一个模型综合
+p.Combine = func(ctx context.Context, req llm.Request, cands []*llm.Response) (*llm.Response, error) { ... }
+resp, _ := p.Run(ctx, req)
+```
+
 **事件父子归因**:`RunStream` 的每条 `Event` 都带 `AgentName`(`Runner.Name`)与 `TriggerType`/`TriggerID`
 (`TriggerUser`/`TriggerToolCall`/`TriggerTransfer`),多 agent 场景下可归因「由谁 / 因何触发」。
 编排点(`AgentAsTool` / `Team`)在调子 agent 前用 `WithTrigger(ctx, tt, id)` 标注来源。
 
 > 可运行示例见 [`agent/example_test.go`](agent/example_test.go)(`go test -run Example ./agent/`,离线 stub、无需 key)。
+
+### 鲁棒性开关(工具参数容错 / 上下文压缩 / 消息合并)
+
+三个 opt-in、纯确定性(不额外调模型)的开关,按需打开:
+
+- **`RepairToolArgs`**:模型给出的 tool_call 参数常"几乎合法"(尾逗号、单引号、裸 key、被 ```围栏包住、
+  JS/Py 常量、注释)。开启后,当参数 `json.Valid` 失败时先用 `agent.RepairJSON` 尽力修复,**修好且重新
+  校验通过才**交给 `Tool.Call`,否则原样透传——绝不会把更坏的输入喂给工具。
+- **`Compactor`**:工具密集的长跑里历史 tool 结果会撑爆上下文。`Runner.Compactor` 在每轮调用前对**发出的
+  投影**做 token 估算 + 截断最旧的大 tool 结果(末尾 `KeepRecent` 条完整保留),规范历史保持完整、每轮重新
+  投影。与 session 的跨轮滚动摘要互补(那个要调模型,这个不调)。
+- **`MergeConsecutive` / `MergeMessagesHook`**:合并相邻同角色(system/user/assistant)消息(`Tool` 永不合并),
+  用于某些要求角色严格交替的 provider,或注入 system/Steer/nudge 后规整请求。可直接当 `BeforeModel` Hook 挂。
+
+```go
+r := &agent.Runner{
+    Client:         cli,
+    Tools:          tools,
+    RepairToolArgs: true,                                   // 容忍坏 JSON 参数
+    Compactor:      &agent.Compactor{MaxTokens: 6000},      // 长跑压缩历史 tool 结果
+    Hooks:          agent.Hooks{BeforeModel: agent.MergeMessagesHook("")}, // 规整消息
+}
+```
 
 ### 人工审批(human-in-the-loop)
 

--- a/contrib/llm/agent/agent.go
+++ b/contrib/llm/agent/agent.go
@@ -11,11 +11,17 @@
 // 支持 Run(同步 Generate)与 RunStream(Stream 推 EventToken + 步骤事件,ctx 可取消);
 // 同轮多 tool 默认可并行;工具权限三态;Steer;Hooks。
 //
-// 统一编排:Runner / Chain / Team / BestOfN / VerifyLoop 都实现同一 Agent(+ 可选 StreamAgent)
-// 契约,可互相嵌套——AgentAsTool 把任意 Agent 包成工具、Chain 按序跑、Team 靠 HANDOFF 文本标记
-// 做带 loop-safety 护栏的多 agent 移交、BestOfN/VerifyLoop 在任意 Agent 上加采样/校验策略。
-// Planner 接缝(ReActPlanner)可在循环前注入规划指令、逐轮后处理响应。RunStream 的 Event 带
-// AgentName/TriggerType/TriggerID,支持多 agent 场景下的父子归因(见 WithTrigger)。
+// 统一编排:Runner / Chain / Team / Parallel / BestOfN / VerifyLoop 都实现同一 Agent(+ 可选
+// StreamAgent)契约,可互相嵌套——AgentAsTool 把任意 Agent 包成工具、Chain 按序跑、Team 靠
+// HANDOFF 文本标记做带 loop-safety 护栏的多 agent 移交、Parallel 把不同 Agent 并发扇出后经可插拔
+// Combiner 合并、BestOfN/VerifyLoop 在任意 Agent 上加采样/校验策略。Planner 接缝(ReActPlanner)
+// 可在循环前注入规划指令、逐轮后处理响应。RunStream 的 Event 带 AgentName/TriggerType/TriggerID,
+// 支持多 agent 场景下的父子归因(见 WithTrigger)。
+//
+// 鲁棒性开关(均 opt-in、纯确定性):RepairToolArgs 在工具参数 json.Valid 失败时用 RepairJSON
+// 尽力修复(修好且重校验通过才采纳);Compactor 在每轮调用前对发出的历史 tool 结果做 token 截断
+// 投影,防止长跑上下文膨胀(不动规范历史、不调模型);MergeConsecutive/MergeMessagesHook 合并相邻
+// 同角色消息(某些 provider 要求角色交替)。
 package agent
 
 import (
@@ -238,6 +244,15 @@ type Runner struct {
 
 	// Steer 中途插话信箱。可为 nil(不启用)。
 	Steer *Steer
+
+	// RepairToolArgs 开启工具参数 JSON 容错:当模型给出的 tool_call 参数 json.Valid 失败时,
+	// 先用 RepairJSON 尽力修复(尾逗号/单引号/裸 key/代码围栏等),修好且重校验通过才交给
+	// Tool.Call。默认关闭。
+	RepairToolArgs bool
+
+	// Compactor 可选:每轮模型调用前对将发出的消息做确定性压缩(截断过大的历史 tool 结果),
+	// 防止长跑上下文膨胀。只作用于发给模型的投影,内部规范历史保持完整。nil=不启用。
+	Compactor *Compactor
 }
 
 var _ StreamAgent = (*Runner)(nil)
@@ -328,6 +343,11 @@ func (r *Runner) run(ctx context.Context, req llm.Request, emit func(Event)) (*l
 				return last, err
 			}
 			msgs = req.Messages
+		}
+
+		// 运行内压缩:只作用于本次调用的投影,规范历史 msgs 保持完整(下轮基于完整历史重新投影)。
+		if r.Compactor != nil {
+			req.Messages = r.Compactor.Project(req.Messages)
 		}
 
 		resp, err := r.callModel(ctx, req, step, emit)
@@ -515,7 +535,13 @@ func (r *Runner) dispatch(ctx context.Context, byName map[string]Tool, tc llm.To
 			return msg, nil
 		}
 	}
-	out, err := t.Call(ctx, tc.Arguments)
+	args := tc.Arguments
+	if r.RepairToolArgs && len(args) > 0 && !json.Valid(args) {
+		if fixed, ok := RepairJSON(args); ok {
+			args = fixed
+		}
+	}
+	out, err := t.Call(ctx, args)
 	if err != nil {
 		return "error: " + err.Error(), nil
 	}

--- a/contrib/llm/agent/compaction.go
+++ b/contrib/llm/agent/compaction.go
@@ -1,0 +1,129 @@
+package agent
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/rushteam/beauty/contrib/llm"
+)
+
+// ==== 运行内上下文压缩:Compactor ====
+//
+// 工具密集的长跑里,历史 tool 结果消息会不断累积、撑爆上下文。Compactor 在**每轮模型调用前**
+// 对将要发出的消息做一次确定性压缩:估算总 token,超阈值时从最旧的、过大的 tool 结果开始截断,
+// 直到降到阈值以下或没有可截断的了。末尾 KeepRecent 条消息完整保留(最近上下文最重要)。
+//
+// 与 session 子包的滚动摘要不同:摘要是**跨轮**、要调模型生成概要;Compactor 是**单轮内**、
+// 纯 token 计数 + 截断,**不调用模型**,零额外延迟与费用。二者可叠加。
+//
+// 关键:压缩只作用于发给模型的**投影**副本,Runner 内部的规范历史(msgs)保持完整——因此每轮都
+// 基于完整历史重新投影,不会永久丢信息。只截断 Role=Tool 的消息(通常最大且最可截),不动对话消息。
+//
+// 机制而非策略:阈值、保留窗口、单条上限、token 估算器都可调,默认给一组温和值。
+
+// Compactor 配置运行内 tool 结果压缩。挂到 Runner.Compactor(nil=不启用)。
+type Compactor struct {
+	// MaxTokens 是触发压缩的估算 token 阈值:整个消息序列估算超过它才压缩。<=0 用默认 4000。
+	MaxTokens int
+	// KeepRecent 是末尾完整保留、不参与压缩的消息条数。<=0 用默认 6。
+	KeepRecent int
+	// ToolResultMaxRunes 是被压缩的单条 tool 结果保留的最大字符数(其后加省略标记)。<=0 用默认 256。
+	ToolResultMaxRunes int
+	// Estimate 估算一段文本的 token 数。nil 用默认(约 4 字节/token 的粗略估算)。
+	Estimate func(string) int
+}
+
+func (c *Compactor) maxTokens() int {
+	if c.MaxTokens > 0 {
+		return c.MaxTokens
+	}
+	return 4000
+}
+
+func (c *Compactor) keepRecent() int {
+	if c.KeepRecent > 0 {
+		return c.KeepRecent
+	}
+	return 6
+}
+
+func (c *Compactor) toolResultMaxRunes() int {
+	if c.ToolResultMaxRunes > 0 {
+		return c.ToolResultMaxRunes
+	}
+	return 256
+}
+
+func (c *Compactor) estimate(s string) int {
+	if c.Estimate != nil {
+		return c.Estimate(s)
+	}
+	return len(s)/4 + 1
+}
+
+// msgTokens 估算一条消息的 token(含 Content 与各 Part 文本)。
+func (c *Compactor) msgTokens(m llm.Message) int {
+	n := c.estimate(m.Content)
+	for _, p := range m.Parts {
+		n += c.estimate(p.Text)
+	}
+	return n
+}
+
+// Project 返回压缩后的消息投影。若无需压缩则原样返回入参切片(不复制);否则返回新切片,
+// 只截断最旧的、超过单条上限的 tool 结果,直到估算总量降至阈值以下或无更多可截。入参不被改动。
+// Runner.Compactor 每轮自动调用它;也可单独调用以在别处复用同一压缩逻辑。
+func (c *Compactor) Project(msgs []llm.Message) []llm.Message {
+	total := 0
+	for _, m := range msgs {
+		total += c.msgTokens(m)
+	}
+	if total <= c.maxTokens() {
+		return msgs
+	}
+
+	limit := len(msgs) - c.keepRecent() // [0,limit) 为可压缩区间
+	maxRunes := c.toolResultMaxRunes()
+	var out []llm.Message // 惰性分配:首次真正截断时才拷贝
+	for i := range limit {
+		m := msgs[i]
+		if total <= c.maxTokens() {
+			break
+		}
+		if m.Role != llm.Tool || utf8.RuneCountInString(m.Content) <= maxRunes {
+			continue
+		}
+		if out == nil {
+			// 首次截断才拷贝:append 到 nil 会分配新底层数组并复制各消息值,
+			// 后续对 out[i] 的重赋值不会影响入参 msgs。
+			out = append(out, msgs...)
+		}
+		before := c.msgTokens(m)
+		truncated := m
+		truncated.Content = truncateRunes(m.Content, maxRunes)
+		out[i] = truncated
+		total += c.msgTokens(truncated) - before
+	}
+	if out == nil {
+		return msgs
+	}
+	return out
+}
+
+// truncateRunes 把 s 截到前 n 个字符,并附省略标记说明省略了多少字符。
+func truncateRunes(s string, n int) string {
+	total := utf8.RuneCountInString(s)
+	if total <= n {
+		return s
+	}
+	// 定位第 n 个 rune 的字节位置。
+	cnt, cut := 0, len(s)
+	for idx := range s {
+		if cnt == n {
+			cut = idx
+			break
+		}
+		cnt++
+	}
+	return s[:cut] + fmt.Sprintf("…[compacted: %d/%d runes omitted]", total-n, total)
+}

--- a/contrib/llm/agent/compaction_test.go
+++ b/contrib/llm/agent/compaction_test.go
@@ -1,0 +1,100 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rushteam/beauty/contrib/llm"
+	"github.com/rushteam/beauty/contrib/llm/agent"
+)
+
+func bigStr(n int) string { return strings.Repeat("x", n) }
+
+// 未超阈值:原样返回,不截断。
+func TestCompactor_BelowThreshold(t *testing.T) {
+	c := &agent.Compactor{MaxTokens: 100000}
+	in := []llm.Message{
+		{Role: llm.User, Content: "hi"},
+		{Role: llm.Tool, ToolCallID: "1", Content: bigStr(1000)},
+	}
+	out := c.Project(in)
+	if len(out) != 2 || out[1].Content != in[1].Content {
+		t.Fatalf("未超阈值不应改动: %+v", out)
+	}
+}
+
+// 超阈值:最旧的大 tool 结果被截断,最近 KeepRecent 条完整保留,入参不被改动。
+func TestCompactor_TruncatesOldToolResults(t *testing.T) {
+	c := &agent.Compactor{MaxTokens: 100, KeepRecent: 1, ToolResultMaxRunes: 50}
+	in := []llm.Message{
+		{Role: llm.User, Content: "问题"},
+		{Role: llm.Assistant, ToolCalls: []llm.ToolCall{{ID: "1", Name: "t"}}},
+		{Role: llm.Tool, ToolCallID: "1", Content: bigStr(4000)}, // 旧的大结果 → 应被截断
+		{Role: llm.Assistant, ToolCalls: []llm.ToolCall{{ID: "2", Name: "t"}}},
+		{Role: llm.Tool, ToolCallID: "2", Content: bigStr(4000)}, // 最近一条 → KeepRecent 保护
+	}
+	orig := in[2].Content
+	out := c.Project(in)
+
+	if len(out) != 5 {
+		t.Fatalf("条数不应变: %d", len(out))
+	}
+	if len([]rune(out[2].Content)) >= 4000 || !strings.Contains(out[2].Content, "compacted") {
+		t.Fatalf("旧 tool 结果应被截断并带标记: len=%d", len([]rune(out[2].Content)))
+	}
+	if out[4].Content != in[4].Content {
+		t.Fatalf("最近 KeepRecent 条不应被截断")
+	}
+	// 入参保持完整。
+	if in[2].Content != orig {
+		t.Fatal("Project 不应改动入参底层")
+	}
+}
+
+// 非 tool 的大消息(如 user)即便超大也不截断——只压 tool 结果。
+func TestCompactor_OnlyToolResults(t *testing.T) {
+	c := &agent.Compactor{MaxTokens: 10, KeepRecent: 1, ToolResultMaxRunes: 10}
+	in := []llm.Message{
+		{Role: llm.User, Content: bigStr(4000)},
+		{Role: llm.Assistant, Content: "ok"},
+	}
+	out := c.Project(in)
+	if out[0].Content != in[0].Content {
+		t.Fatal("user 大消息不应被截断")
+	}
+}
+
+// 集成:Runner.Compactor 让发给模型的历史 tool 结果在第 3 轮被截断,而规范历史不受影响
+// (下一轮仍能拿到,但每轮都基于完整历史重新投影)。
+func TestRunner_Compactor(t *testing.T) {
+	tool := agent.Func("t", "", nil, func(_ context.Context, _ json.RawMessage) (string, error) {
+		return bigStr(4000), nil
+	})
+	fc := &fakeClient{steps: []*llm.Response{
+		{ToolCalls: []llm.ToolCall{{ID: "c1", Name: "t"}}},
+		{ToolCalls: []llm.ToolCall{{ID: "c2", Name: "t"}}},
+		{Content: "done"},
+	}}
+	r := &agent.Runner{
+		Client:    fc,
+		Tools:     []agent.Tool{tool},
+		Compactor: &agent.Compactor{MaxTokens: 100, KeepRecent: 1, ToolResultMaxRunes: 50},
+	}
+	if _, err := r.Run(context.Background(), llm.Request{Model: "m", Messages: []llm.Message{{Role: llm.User, Content: "go"}}}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	// 第 3 轮请求:[user, asst(c1), tool(BIG), asst(c2), tool(BIG)];
+	// 第一条 BIG(index 2)在 KeepRecent 之外 → 应被截断。
+	msgs := fc.lastReq.Messages
+	if len(msgs) != 5 {
+		t.Fatalf("第三轮消息数应为 5: %d", len(msgs))
+	}
+	if !strings.Contains(msgs[2].Content, "compacted") {
+		t.Fatalf("旧的大 tool 结果应被压缩投影: len=%d", len(msgs[2].Content))
+	}
+	if len([]rune(msgs[4].Content)) < 4000 {
+		t.Fatalf("最近的 tool 结果应完整保留: len=%d", len([]rune(msgs[4].Content)))
+	}
+}

--- a/contrib/llm/agent/interface_test.go
+++ b/contrib/llm/agent/interface_test.go
@@ -7,6 +7,7 @@ var (
 	_ agent.StreamAgent = (*agent.Runner)(nil)
 	_ agent.StreamAgent = (*agent.Chain)(nil)
 	_ agent.StreamAgent = (*agent.Team)(nil)
+	_ agent.StreamAgent = (*agent.Parallel)(nil)
 	_ agent.Agent       = (*agent.BestOfN)(nil)
 	_ agent.Agent       = (*agent.VerifyLoop)(nil)
 )

--- a/contrib/llm/agent/jsonrepair.go
+++ b/contrib/llm/agent/jsonrepair.go
@@ -1,0 +1,375 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+)
+
+// ==== 工具参数 JSON 容错修复 ====
+//
+// 模型吐出的 tool_call 参数常常是"几乎合法"的 JSON:被 ```代码围栏包住、尾逗号、用单引号、
+// key 没加引号、混入 JS/Python 常量(True/False/None/NaN/undefined)或注释、字符串里有裸换行。
+// RepairJSON 尽力把这类近似 JSON 修成合法 JSON。它是一个薄的单遍扫描重写器(非完整的递归下降
+// 解析器),覆盖上述最常见的模型笔误,纯标准库。
+//
+// 安全约定:RepairJSON 只有在修复结果**重新通过 json.Valid** 时才返回 ok=true;否则返回
+// (nil,false),调用方应保留原始字节。因此即便修复不完美,也绝不会把更坏的输入喂给下游。
+//
+// 接线:Runner.RepairToolArgs=true 时,dispatch 在 tool_call 参数 json.Valid 失败时先试修复,
+// 修好(且重校验通过)才把修复后的参数交给 Tool.Call。默认关闭,是 opt-in 机制而非策略。
+
+// RepairJSON 尽力把近似 JSON 修成合法 JSON。修复结果重新通过 json.Valid 才返回 ok=true。
+func RepairJSON(in []byte) (out []byte, ok bool) {
+	s := stripCodeFence(string(in))
+	s = extractJSONSpan(s)
+	if s == "" {
+		return nil, false
+	}
+	fixed := (&jsonRepairer{src: s}).rewrite()
+	if json.Valid([]byte(fixed)) {
+		return []byte(fixed), true
+	}
+	return nil, false
+}
+
+// stripCodeFence 去掉 ```json ... ``` / ``` ... ``` 代码围栏(取围栏内内容)。
+func stripCodeFence(s string) string {
+	t := strings.TrimSpace(s)
+	if !strings.HasPrefix(t, "```") {
+		return s
+	}
+	t = t[3:]
+	// 去掉紧跟的语言标注行(如 json)。
+	if i := strings.IndexByte(t, '\n'); i >= 0 {
+		if lang := strings.TrimSpace(t[:i]); lang == "" || isWord(lang) {
+			t = t[i+1:]
+		}
+	}
+	if i := strings.LastIndex(t, "```"); i >= 0 {
+		t = t[:i]
+	}
+	return t
+}
+
+// extractJSONSpan 截取从首个 { 或 [ 到与之匹配的末个 } 或 ] 之间的片段,丢弃前后散文。
+// 仅按最外层括号粗略配对(字符串内的括号不计),用于剥离模型在 JSON 前后附带的解释文字。
+func extractJSONSpan(s string) string {
+	start := strings.IndexAny(s, "{[")
+	if start < 0 {
+		return strings.TrimSpace(s)
+	}
+	var last int = -1
+	depth := 0
+	inStr := false
+	var quote byte
+	esc := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			if esc {
+				esc = false
+			} else if c == '\\' {
+				esc = true
+			} else if c == quote {
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'':
+			inStr, quote = true, c
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth == 0 {
+				last = i
+			}
+		}
+	}
+	if last > start {
+		return s[start : last+1]
+	}
+	return s[start:] // 未闭合:交给重写器补齐
+}
+
+// jsonRepairer 是单遍扫描重写器,维护一个容器栈以识别 object 的 key 位置。
+type jsonRepairer struct {
+	src string
+	i   int
+	out strings.Builder
+	// stack 记录当前所处容器:'{' 或 '['。
+	stack []byte
+	// expectKey 表示在 object 中当前处于 key 位置(刚进 { 或刚过 ,)。
+	expectKey bool
+}
+
+func (r *jsonRepairer) inObject() bool {
+	return len(r.stack) > 0 && r.stack[len(r.stack)-1] == '{'
+}
+
+func (r *jsonRepairer) rewrite() string {
+	for r.i < len(r.src) {
+		r.skipSpaceAndComments()
+		if r.i >= len(r.src) {
+			break
+		}
+		c := r.src[r.i]
+		switch {
+		case c == '{':
+			r.out.WriteByte('{')
+			r.stack = append(r.stack, '{')
+			r.expectKey = true
+			r.i++
+		case c == '[':
+			r.out.WriteByte('[')
+			r.stack = append(r.stack, '[')
+			r.expectKey = false
+			r.i++
+		case c == '}' || c == ']':
+			r.trimTrailingComma()
+			r.out.WriteByte(c)
+			if len(r.stack) > 0 {
+				r.stack = r.stack[:len(r.stack)-1]
+			}
+			r.expectKey = false
+			r.i++
+		case c == ',':
+			// 尾逗号:后面(跳过空白/注释)紧跟 } 或 ] 时丢弃。
+			if r.commaIsTrailing() {
+				r.i++
+				continue
+			}
+			r.out.WriteByte(',')
+			r.i++
+			r.expectKey = r.inObject()
+		case c == ':':
+			r.out.WriteByte(':')
+			r.i++
+			r.expectKey = false
+		case c == '"' || c == '\'':
+			r.writeString()
+			r.expectKey = false
+		default:
+			if r.inObject() && r.expectKey && isIdentStart(c) {
+				r.writeBareKey()
+			} else {
+				r.writeLiteral()
+			}
+			r.expectKey = false
+		}
+	}
+	return r.out.String()
+}
+
+// skipSpaceAndComments 跳过空白与 // 行注释、/* */ 块注释(不写入输出)。
+func (r *jsonRepairer) skipSpaceAndComments() {
+	for r.i < len(r.src) {
+		c := r.src[r.i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			r.out.WriteByte(c)
+			r.i++
+		case c == '/' && r.i+1 < len(r.src) && r.src[r.i+1] == '/':
+			r.i += 2
+			for r.i < len(r.src) && r.src[r.i] != '\n' {
+				r.i++
+			}
+		case c == '/' && r.i+1 < len(r.src) && r.src[r.i+1] == '*':
+			r.i += 2
+			for r.i+1 < len(r.src) && !(r.src[r.i] == '*' && r.src[r.i+1] == '/') {
+				r.i++
+			}
+			r.i += 2
+			if r.i > len(r.src) {
+				r.i = len(r.src)
+			}
+		default:
+			return
+		}
+	}
+}
+
+// commaIsTrailing 从当前逗号向后看,跳过空白/注释后若为 } 或 ] 则该逗号为尾逗号。
+func (r *jsonRepairer) commaIsTrailing() bool {
+	j := r.i + 1
+	for j < len(r.src) {
+		c := r.src[j]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			j++
+		case c == '/' && j+1 < len(r.src) && r.src[j+1] == '/':
+			j += 2
+			for j < len(r.src) && r.src[j] != '\n' {
+				j++
+			}
+		case c == '/' && j+1 < len(r.src) && r.src[j+1] == '*':
+			j += 2
+			for j+1 < len(r.src) && !(r.src[j] == '*' && r.src[j+1] == '/') {
+				j++
+			}
+			j += 2
+		default:
+			return c == '}' || c == ']'
+		}
+	}
+	return true // 后面只剩空白 → 视作尾逗号丢弃
+}
+
+// trimTrailingComma 在写入 } / ] 前,去掉输出末尾已写入的尾逗号(及其后空白)。
+func (r *jsonRepairer) trimTrailingComma() {
+	s := r.out.String()
+	end := len(s)
+	j := end
+	for j > 0 {
+		c := s[j-1]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			j--
+			continue
+		}
+		break
+	}
+	if j > 0 && s[j-1] == ',' {
+		r.out.Reset()
+		r.out.WriteString(s[:j-1])
+		r.out.WriteString(s[j:end]) // 保留逗号后的空白排版
+	}
+}
+
+// writeString 读取一个字符串字面量(定界符可为 " 或 '),统一以双引号输出,转义内部双引号与裸换行。
+func (r *jsonRepairer) writeString() {
+	quote := r.src[r.i]
+	r.i++
+	r.out.WriteByte('"')
+	for r.i < len(r.src) {
+		c := r.src[r.i]
+		if c == '\\' {
+			// 保留转义序列;单引号定界时的 \' 输出为字面 '。
+			if r.i+1 < len(r.src) {
+				nxt := r.src[r.i+1]
+				if quote == '\'' && nxt == '\'' {
+					r.out.WriteByte('\'')
+					r.i += 2
+					continue
+				}
+				r.out.WriteByte('\\')
+				r.out.WriteByte(nxt)
+				r.i += 2
+				continue
+			}
+			r.out.WriteString("\\\\")
+			r.i++
+			continue
+		}
+		if c == quote {
+			r.i++
+			r.out.WriteByte('"')
+			return
+		}
+		switch c {
+		case '"':
+			r.out.WriteString("\\\"") // 单引号串里出现的裸双引号需转义
+		case '\n':
+			r.out.WriteString("\\n")
+		case '\r':
+			r.out.WriteString("\\r")
+		case '\t':
+			r.out.WriteString("\\t")
+		default:
+			r.out.WriteByte(c)
+		}
+		r.i++
+	}
+	r.out.WriteByte('"') // 未闭合 → 补齐
+}
+
+// writeBareKey 读取一个未加引号的对象 key(标识符),以双引号输出。
+func (r *jsonRepairer) writeBareKey() {
+	start := r.i
+	for r.i < len(r.src) && isIdentPart(r.src[r.i]) {
+		r.i++
+	}
+	r.out.WriteByte('"')
+	r.out.WriteString(r.src[start:r.i])
+	r.out.WriteByte('"')
+}
+
+// writeLiteral 读取一个裸 token(数字/true/false/null 或需归一化的 JS/Py 常量),规范化后输出。
+func (r *jsonRepairer) writeLiteral() {
+	start := r.i
+	for r.i < len(r.src) {
+		c := r.src[r.i]
+		if c == ',' || c == '}' || c == ']' || c == ':' || c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			break
+		}
+		r.i++
+	}
+	tok := r.src[start:r.i]
+	switch tok {
+	case "True":
+		r.out.WriteString("true")
+	case "False":
+		r.out.WriteString("false")
+	case "None", "null":
+		r.out.WriteString("null")
+	case "NaN", "Infinity", "-Infinity", "undefined", "":
+		r.out.WriteString("null")
+	default:
+		r.out.WriteString(normalizeNumber(tok))
+	}
+}
+
+// normalizeNumber 归一化数字:去掉前导 +、修正 .5 → 0.5、5. → 5.0;非数字原样返回。
+func normalizeNumber(tok string) string {
+	t := tok
+	neg := ""
+	t = strings.TrimPrefix(t, "+")
+	if strings.HasPrefix(t, "-") {
+		neg, t = "-", t[1:]
+	}
+	if t == "" || !isNumberish(t) {
+		return tok
+	}
+	if strings.HasPrefix(t, ".") {
+		t = "0" + t
+	}
+	if strings.HasSuffix(t, ".") {
+		t += "0"
+	}
+	return neg + t
+}
+
+func isNumberish(t string) bool {
+	dot := false
+	for i := 0; i < len(t); i++ {
+		c := t[i]
+		switch {
+		case c >= '0' && c <= '9':
+		case c == '.' && !dot:
+			dot = true
+		case (c == 'e' || c == 'E') && i > 0:
+		case (c == '+' || c == '-') && i > 0 && (t[i-1] == 'e' || t[i-1] == 'E'):
+		default:
+			return false
+		}
+	}
+	return strings.ContainsAny(t, "0123456789")
+}
+
+func isWord(s string) bool {
+	for _, r := range s {
+		if !(r == '_' || r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9') {
+			return false
+		}
+	}
+	return utf8.RuneCountInString(s) > 0
+}
+
+func isIdentStart(c byte) bool {
+	return c == '_' || c == '$' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}
+
+func isIdentPart(c byte) bool {
+	return isIdentStart(c) || (c >= '0' && c <= '9') || c == '-' || c == '.'
+}

--- a/contrib/llm/agent/jsonrepair_test.go
+++ b/contrib/llm/agent/jsonrepair_test.go
@@ -1,0 +1,118 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/rushteam/beauty/contrib/llm"
+	"github.com/rushteam/beauty/contrib/llm/agent"
+)
+
+// RepairJSON 覆盖常见的模型笔误,修复结果必须重新通过 json.Valid。
+func TestRepairJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want map[string]any // 修复后反序列化应相等(仅对象类用例填);nil 表示只校验合法性
+	}{
+		{"trailing comma", `{"a":1,"b":2,}`, map[string]any{"a": 1.0, "b": 2.0}},
+		{"single quotes", `{'a':'x'}`, map[string]any{"a": "x"}},
+		{"bare keys", `{a:1, b:"y"}`, map[string]any{"a": 1.0, "b": "y"}},
+		{"code fence", "```json\n{\"a\":1}\n```", map[string]any{"a": 1.0}},
+		{"py constants", `{"ok":True,"no":False,"nil":None}`, map[string]any{"ok": true, "no": false, "nil": nil}},
+		{"line comment", "{\"a\":1 // note\n}", map[string]any{"a": 1.0}},
+		{"block comment", `{"a":/* c */1}`, map[string]any{"a": 1.0}},
+		{"prose around", `Sure! {"a":1} hope that helps`, map[string]any{"a": 1.0}},
+		{"trailing comma in array", `{"xs":[1,2,3,]}`, nil},
+		{"leading dot number", `{"n":.5}`, map[string]any{"n": 0.5}},
+		{"nested + mixed", `{a:{'b':[1,2,],},c:True,}`, nil},
+		{"unescaped newline", "{\"a\":\"li\nne\"}", map[string]any{"a": "li\nne"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, ok := agent.RepairJSON([]byte(c.in))
+			if !ok {
+				t.Fatalf("修复失败: %q", c.in)
+			}
+			if !json.Valid(out) {
+				t.Fatalf("修复结果非法 JSON: %q -> %q", c.in, out)
+			}
+			if c.want != nil {
+				var got map[string]any
+				if err := json.Unmarshal(out, &got); err != nil {
+					t.Fatalf("反序列化: %v (%q)", err, out)
+				}
+				if len(got) != len(c.want) {
+					t.Fatalf("字段数不符: got %v want %v", got, c.want)
+				}
+				for k, v := range c.want {
+					if got[k] != v {
+						t.Fatalf("键 %q: got %#v want %#v (整体 %q)", k, got[k], v, out)
+					}
+				}
+			}
+		})
+	}
+}
+
+// 已经合法的 JSON 也应原样修复通过(幂等)。
+func TestRepairJSON_AlreadyValid(t *testing.T) {
+	in := `{"a":1,"b":["x","y"],"c":{"d":true}}`
+	out, ok := agent.RepairJSON([]byte(in))
+	if !ok || !json.Valid(out) {
+		t.Fatalf("合法输入应修复通过: ok=%v out=%q", ok, out)
+	}
+}
+
+// 无法救回的输入返回 ok=false(调用方保留原文)。
+func TestRepairJSON_Unrepairable(t *testing.T) {
+	if _, ok := agent.RepairJSON([]byte("this is not json at all")); ok {
+		t.Fatal("纯散文不应被判为修复成功")
+	}
+}
+
+// 集成:RepairToolArgs 让工具循环容忍模型给出的坏 JSON 参数(尾逗号+单引号)。
+func TestRunner_RepairToolArgs(t *testing.T) {
+	var seen string
+	tool := agent.Func("echo", "回显", nil, func(_ context.Context, args json.RawMessage) (string, error) {
+		seen = string(args)
+		return "ok", nil
+	})
+	fc := &fakeClient{steps: []*llm.Response{
+		{ToolCalls: []llm.ToolCall{{ID: "c1", Name: "echo", Arguments: json.RawMessage(`{'x':1,}`)}}},
+		{Content: "done"},
+	}}
+	r := &agent.Runner{Client: fc, Tools: []agent.Tool{tool}, RepairToolArgs: true}
+	if _, err := r.Run(context.Background(), llm.Request{Model: "m"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !json.Valid([]byte(seen)) {
+		t.Fatalf("工具应收到修复后的合法 JSON, got %q", seen)
+	}
+	var got map[string]any
+	_ = json.Unmarshal([]byte(seen), &got)
+	if got["x"] != 1.0 {
+		t.Fatalf("修复后参数不对: %q", seen)
+	}
+}
+
+// 关闭修复时(默认),坏 JSON 原样传给工具(工具自行处理)。
+func TestRunner_RepairToolArgs_Disabled(t *testing.T) {
+	var seen string
+	tool := agent.Func("echo", "", nil, func(_ context.Context, args json.RawMessage) (string, error) {
+		seen = string(args)
+		return "ok", nil
+	})
+	fc := &fakeClient{steps: []*llm.Response{
+		{ToolCalls: []llm.ToolCall{{ID: "c1", Name: "echo", Arguments: json.RawMessage(`{'x':1,}`)}}},
+		{Content: "done"},
+	}}
+	r := &agent.Runner{Client: fc, Tools: []agent.Tool{tool}} // RepairToolArgs 默认 false
+	if _, err := r.Run(context.Background(), llm.Request{Model: "m"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if seen != `{'x':1,}` {
+		t.Fatalf("未开启修复时应原样透传, got %q", seen)
+	}
+}

--- a/contrib/llm/agent/messagemerger.go
+++ b/contrib/llm/agent/messagemerger.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"context"
+
+	"github.com/rushteam/beauty/contrib/llm"
+)
+
+// ==== 相邻同角色消息合并 ====
+//
+// 某些 provider 要求消息角色严格交替(user/assistant 相间),或在注入 system 背景、Steer 插话、
+// 各类 nudge 之后,请求里出现了连续多条同角色消息。MergeConsecutive 把相邻且同为
+// system/user/assistant 的消息合并成一条:文本用 sep 连接,ToolCalls 顺序拼接,Parts 顺序拼接。
+//
+// Role=Tool 的消息**永不合并**——它靠 ToolCallID 与某次具体调用一一对应,合并会破坏语义。
+//
+// 机制而非策略:是否需要合并、用什么分隔符,由使用方决定(常见做法是把 MergeMessagesHook 挂到
+// Runner.Hooks.BeforeModel,在每轮请求发出前规整)。
+
+// MergeConsecutive 合并 msgs 中相邻且同角色(system/user/assistant)的消息,返回新切片,
+// 不改动入参底层数组。sep 为空时用 "\n\n" 连接文本。
+func MergeConsecutive(msgs []llm.Message, sep string) []llm.Message {
+	if sep == "" {
+		sep = "\n\n"
+	}
+	out := make([]llm.Message, 0, len(msgs))
+	for _, m := range msgs {
+		if n := len(out); n > 0 && mergeable(out[n-1], m) {
+			out[n-1] = mergeInto(out[n-1], m, sep)
+			continue
+		}
+		out = append(out, cloneMessage(m))
+	}
+	return out
+}
+
+// MergeMessagesHook 返回一个把 MergeConsecutive 作用于每轮请求消息的 BeforeModel Hook。
+// 用法:runner.Hooks.BeforeModel = agent.MergeMessagesHook("")。
+func MergeMessagesHook(sep string) func(ctx context.Context, step int, req *llm.Request) error {
+	return func(_ context.Context, _ int, req *llm.Request) error {
+		req.Messages = MergeConsecutive(req.Messages, sep)
+		return nil
+	}
+}
+
+// mergeable 判断相邻两条消息是否可合并:同角色,且都不是 Tool 消息。
+func mergeable(a, b llm.Message) bool {
+	return a.Role == b.Role && a.Role != llm.Tool
+}
+
+// mergeInto 把 b 合并进 a 的副本:文本用 sep 连接(两边都非空时),Parts/ToolCalls 顺序拼接。
+func mergeInto(a, b llm.Message, sep string) llm.Message {
+	m := cloneMessage(a)
+	switch {
+	case m.Content == "":
+		m.Content = b.Content
+	case b.Content != "":
+		m.Content += sep + b.Content
+	}
+	if len(b.Parts) > 0 {
+		m.Parts = append(m.Parts, cloneParts(b.Parts)...)
+	}
+	if len(b.ToolCalls) > 0 {
+		m.ToolCalls = append(m.ToolCalls, b.ToolCalls...)
+	}
+	return m
+}
+
+// cloneMessage 深拷贝会被追加的切片字段,避免合并时改到调用方底层数组。
+func cloneMessage(m llm.Message) llm.Message {
+	c := m
+	c.Parts = cloneParts(m.Parts)
+	if len(m.ToolCalls) > 0 {
+		c.ToolCalls = append([]llm.ToolCall(nil), m.ToolCalls...)
+	}
+	return c
+}
+
+func cloneParts(ps []llm.Part) []llm.Part {
+	if len(ps) == 0 {
+		return nil
+	}
+	return append([]llm.Part(nil), ps...)
+}

--- a/contrib/llm/agent/messagemerger_test.go
+++ b/contrib/llm/agent/messagemerger_test.go
@@ -1,0 +1,86 @@
+package agent_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rushteam/beauty/contrib/llm"
+	"github.com/rushteam/beauty/contrib/llm/agent"
+)
+
+// 相邻同角色合并,不同角色保留,Tool 消息永不合并。
+func TestMergeConsecutive(t *testing.T) {
+	in := []llm.Message{
+		{Role: llm.User, Content: "a"},
+		{Role: llm.User, Content: "b"},
+		{Role: llm.Assistant, Content: "c"},
+		{Role: llm.Tool, ToolCallID: "1", Content: "r1"},
+		{Role: llm.Tool, ToolCallID: "2", Content: "r2"},
+		{Role: llm.User, Content: "d"},
+		{Role: llm.User, Content: "e"},
+	}
+	out := agent.MergeConsecutive(in, "\n")
+	if len(out) != 5 {
+		t.Fatalf("合并后应为 5 条, got %d: %+v", len(out), out)
+	}
+	if out[0].Role != llm.User || out[0].Content != "a\nb" {
+		t.Fatalf("首条应合并为 user a\\nb: %+v", out[0])
+	}
+	if out[1].Role != llm.Assistant || out[1].Content != "c" {
+		t.Fatalf("assistant 应保留: %+v", out[1])
+	}
+	if out[2].Role != llm.Tool || out[3].Role != llm.Tool {
+		t.Fatalf("两条 Tool 不应合并: %+v", out)
+	}
+	if out[4].Content != "d\ne" {
+		t.Fatalf("末尾两条 user 应合并: %+v", out[4])
+	}
+	// 不改动入参。
+	if len(in) != 7 {
+		t.Fatalf("入参被改动: %+v", in)
+	}
+}
+
+// 合并时拼接 ToolCalls(assistant 连发)。
+func TestMergeConsecutive_ToolCalls(t *testing.T) {
+	in := []llm.Message{
+		{Role: llm.Assistant, ToolCalls: []llm.ToolCall{{ID: "1", Name: "x"}}},
+		{Role: llm.Assistant, ToolCalls: []llm.ToolCall{{ID: "2", Name: "y"}}},
+	}
+	out := agent.MergeConsecutive(in, "")
+	if len(out) != 1 || len(out[0].ToolCalls) != 2 {
+		t.Fatalf("assistant tool_calls 应拼接: %+v", out)
+	}
+	// 原切片的 ToolCalls 不被追加污染。
+	if len(in[0].ToolCalls) != 1 {
+		t.Fatalf("入参 ToolCalls 被改动: %+v", in[0])
+	}
+}
+
+// 空文本一侧不产生多余分隔符。
+func TestMergeConsecutive_EmptyContent(t *testing.T) {
+	in := []llm.Message{
+		{Role: llm.Assistant, Content: ""},
+		{Role: llm.Assistant, Content: "hi"},
+	}
+	out := agent.MergeConsecutive(in, "\n\n")
+	if len(out) != 1 || out[0].Content != "hi" {
+		t.Fatalf("空文本不应产生前导分隔符: %+v", out)
+	}
+}
+
+// Hook:在每轮请求发出前规整消息(与 Runner 集成)。
+func TestMergeMessagesHook(t *testing.T) {
+	fc := &fakeClient{steps: []*llm.Response{{Content: "done"}}}
+	r := &agent.Runner{Client: fc, Hooks: agent.Hooks{BeforeModel: agent.MergeMessagesHook("\n\n")}}
+	_, err := r.Run(context.Background(), llm.Request{Model: "m", Messages: []llm.Message{
+		{Role: llm.User, Content: "一"},
+		{Role: llm.User, Content: "二"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := fc.lastReq.Messages; len(got) != 1 || got[0].Content != "一\n\n二" {
+		t.Fatalf("Hook 应在请求前合并连续 user: %+v", got)
+	}
+}

--- a/contrib/llm/agent/parallel.go
+++ b/contrib/llm/agent/parallel.go
@@ -1,0 +1,187 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/rushteam/beauty/contrib/llm"
+)
+
+// ==== 并发扇出组合体:Parallel ====
+//
+// Parallel 把若干**不同的** Agent 并发跑同一个 Request,再用 Combine 把各自的终态响应合并成一个。
+// 它补齐了可组合 Agent 家族里"并发"这一维度:
+//   - Chain    串行:上一步输出喂下一步;
+//   - Team     路由:按 HANDOFF 标记在成员间移交控制权;
+//   - BestOfN  同一 Agent 跑 N 次、择优;
+//   - Parallel 不同 Agent 并发跑、合并。
+//
+// 机制而非策略:如何合并(拼接?投票?再交给一个模型综合?)是 policy,由使用方注入 Combine;
+// 本类型只负责并发调度、错误聚合与事件扇入。Parallel 自身也实现 Agent/StreamAgent,可被 Chain /
+// AgentAsTool / Team 再嵌套(例如"并发调研 → 单 agent 汇总"就是 Chain{Parallel, summarizer})。
+
+// Combiner 把并发跑完的多个响应合并成一个终态响应。cands 与 Parallel.Agents 下标一一对应,
+// 失败或 nil 的分支在对应位置为 nil;调用时保证至少有一个非 nil。
+type Combiner func(ctx context.Context, req llm.Request, cands []*llm.Response) (*llm.Response, error)
+
+// ConcatCombiner 是平凡默认合并器:按 Agents 顺序把各非空响应的 Content 用空行连接,
+// Usage 汇总相加。适合"把并行结果拼给下游再综合"的场景。
+func ConcatCombiner(_ context.Context, _ llm.Request, cands []*llm.Response) (*llm.Response, error) {
+	var parts []string
+	var usage llm.Usage
+	model := ""
+	for _, c := range cands {
+		if c == nil {
+			continue
+		}
+		if c.Content != "" {
+			parts = append(parts, c.Content)
+		}
+		usage.InputTokens += c.Usage.InputTokens
+		usage.OutputTokens += c.Usage.OutputTokens
+		if model == "" {
+			model = c.Model
+		}
+	}
+	return &llm.Response{Content: strings.Join(parts, "\n\n"), Usage: usage, Model: model}, nil
+}
+
+// Parallel 并发运行 Agents 中的每个 Agent(各收到相同 Request),再用 Combine 合并结果。
+// Combine 为 nil 时用 ConcatCombiner。任一分支出错不影响其他分支;全部失败时返回聚合错误。
+type Parallel struct {
+	Name    string
+	Agents  []Agent
+	Combine Combiner
+}
+
+var (
+	_ Agent       = (*Parallel)(nil)
+	_ StreamAgent = (*Parallel)(nil)
+)
+
+// runAll 并发跑所有分支,返回与 Agents 一一对应的响应与错误(失败分支响应可能为 nil)。
+func (p *Parallel) runAll(ctx context.Context, req llm.Request) (resps []*llm.Response, errs []error) {
+	resps = make([]*llm.Response, len(p.Agents))
+	errs = make([]error, len(p.Agents))
+	var wg sync.WaitGroup
+	for i := range p.Agents {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			resps[i], errs[i] = p.Agents[i].Run(ctx, req)
+		}(i)
+	}
+	wg.Wait()
+	return resps, errs
+}
+
+// combine 过滤出成功分支交给 Combine;全部失败返回聚合错误。
+func (p *Parallel) combine(ctx context.Context, req llm.Request, resps []*llm.Response, errs []error) (*llm.Response, error) {
+	var firstErr error
+	any := false
+	for i := range resps {
+		if errs[i] != nil {
+			if firstErr == nil {
+				firstErr = errs[i]
+			}
+			resps[i] = nil
+			continue
+		}
+		if resps[i] != nil {
+			any = true
+		}
+	}
+	if !any {
+		if firstErr != nil {
+			return nil, fmt.Errorf("agent: Parallel all %d branches failed: %w", len(p.Agents), firstErr)
+		}
+		return nil, fmt.Errorf("agent: Parallel produced no responses")
+	}
+	comb := p.Combine
+	if comb == nil {
+		comb = ConcatCombiner
+	}
+	resp, err := comb(ctx, req, resps)
+	if err != nil {
+		return nil, fmt.Errorf("agent: Parallel combine: %w", err)
+	}
+	return resp, nil
+}
+
+// Run 并发跑所有分支并合并结果。
+func (p *Parallel) Run(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	if len(p.Agents) == 0 {
+		return nil, fmt.Errorf("agent: Parallel has no agents")
+	}
+	resps, errs := p.runAll(ctx, req)
+	return p.combine(ctx, req, resps, errs)
+}
+
+// RunStream 实现 StreamAgent:并发跑各分支,支持流式的分支透传其中间事件(token/step/tool,
+// 已由分支自行打好归因),不支持的分支同步跑;各分支的 final/error 内部捕获。全部结束后合并,
+// 对外只产出一条终态 EventFinal(合并结果)。任一分支或合并出错则产出 EventError。
+func (p *Parallel) RunStream(ctx context.Context, req llm.Request) <-chan Event {
+	ch := make(chan Event, 32)
+	go func() {
+		defer close(ch)
+		if len(p.Agents) == 0 {
+			ch <- Event{Type: EventError, AgentName: p.Name, Err: fmt.Errorf("agent: Parallel has no agents")}
+			return
+		}
+		resps := make([]*llm.Response, len(p.Agents))
+		errs := make([]error, len(p.Agents))
+		var wg sync.WaitGroup
+		for i := range p.Agents {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				fev, err := p.streamBranch(ctx, p.Agents[i], req, ch)
+				resps[i], errs[i] = fev.Response, err
+			}(i)
+		}
+		wg.Wait()
+
+		resp, err := p.combine(ctx, req, resps, errs)
+		if err != nil {
+			ch <- Event{Type: EventError, AgentName: p.Name, Err: err}
+			return
+		}
+		ch <- Event{Type: EventFinal, AgentName: p.Name, Response: resp}
+	}()
+	return ch
+}
+
+// streamBranch 跑单个分支:支持 StreamAgent 时透传中间事件、捕获 final/error;否则同步跑并合成 final。
+func (p *Parallel) streamBranch(ctx context.Context, a Agent, req llm.Request, ch chan<- Event) (Event, error) {
+	if sa, ok := a.(StreamAgent); ok {
+		var fev Event
+		var rerr error
+		for ev := range sa.RunStream(ctx, req) {
+			switch ev.Type {
+			case EventFinal:
+				fev = ev
+			case EventError:
+				fev, rerr = ev, ev.Err
+			default:
+				ch <- ev
+			}
+		}
+		return fev, rerr
+	}
+	resp, err := a.Run(ctx, req)
+	tt, tid := triggerFrom(ctx)
+	return Event{Type: EventFinal, Response: resp, AgentName: a.Info().Name, TriggerType: tt, TriggerID: tid}, err
+}
+
+// Info 实现 Agent:汇总各分支暴露的工具声明。
+func (p *Parallel) Info() Info {
+	var tools []llm.ToolDef
+	for _, a := range p.Agents {
+		if a != nil {
+			tools = append(tools, a.Info().Tools...)
+		}
+	}
+	return Info{Name: p.Name, Description: "parallel fan-out", Tools: tools}
+}

--- a/contrib/llm/agent/parallel_test.go
+++ b/contrib/llm/agent/parallel_test.go
@@ -1,0 +1,119 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rushteam/beauty/contrib/llm"
+	"github.com/rushteam/beauty/contrib/llm/agent"
+)
+
+// errClient 的 Generate 总是失败(用于模拟分支失败)。
+type errClient struct{}
+
+func (errClient) Generate(context.Context, llm.Request) (*llm.Response, error) {
+	return nil, errors.New("boom")
+}
+func (errClient) Stream(context.Context, llm.Request) (<-chan llm.Chunk, error) {
+	return nil, errors.New("boom")
+}
+
+// 默认 ConcatCombiner:按 Agents 顺序拼接各分支 Content。
+func TestParallel_DefaultConcat(t *testing.T) {
+	p := &agent.Parallel{Agents: []agent.Agent{
+		&agent.Runner{Name: "a", Client: constClient{content: "结果A"}},
+		&agent.Runner{Name: "b", Client: constClient{content: "结果B"}},
+	}}
+	resp, err := p.Run(context.Background(), llm.Request{Messages: []llm.Message{{Role: llm.User, Content: "q"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Content != "结果A\n\n结果B" {
+		t.Fatalf("content = %q", resp.Content)
+	}
+}
+
+// 自定义 Combiner:可任意综合(这里选最长)。
+func TestParallel_CustomCombiner(t *testing.T) {
+	p := &agent.Parallel{
+		Agents: []agent.Agent{
+			&agent.Runner{Client: constClient{content: "短"}},
+			&agent.Runner{Client: constClient{content: "较长的答案"}},
+		},
+		Combine: func(_ context.Context, _ llm.Request, cands []*llm.Response) (*llm.Response, error) {
+			best := cands[0]
+			for _, c := range cands {
+				if c != nil && (best == nil || len(c.Content) > len(best.Content)) {
+					best = c
+				}
+			}
+			return best, nil
+		},
+	}
+	resp, err := p.Run(context.Background(), llm.Request{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Content != "较长的答案" {
+		t.Fatalf("content = %q", resp.Content)
+	}
+}
+
+// 部分分支失败:失败分支被过滤,仍能合并成功分支。
+func TestParallel_PartialFailure(t *testing.T) {
+	p := &agent.Parallel{Agents: []agent.Agent{
+		&agent.Runner{Client: errClient{}},
+		&agent.Runner{Client: constClient{content: "幸存"}},
+	}}
+	resp, err := p.Run(context.Background(), llm.Request{})
+	if err != nil {
+		t.Fatalf("部分失败仍应合并成功分支: %v", err)
+	}
+	if resp.Content != "幸存" {
+		t.Fatalf("content = %q", resp.Content)
+	}
+}
+
+// 全部失败:返回聚合错误。
+func TestParallel_AllFail(t *testing.T) {
+	p := &agent.Parallel{Agents: []agent.Agent{
+		&agent.Runner{Client: errClient{}},
+		&agent.Runner{Client: errClient{}},
+	}}
+	if _, err := p.Run(context.Background(), llm.Request{}); err == nil {
+		t.Fatal("全部失败应报错")
+	}
+}
+
+// RunStream:透传各分支中间事件,对外仅一条合并后的终态 EventFinal。
+func TestParallel_RunStream(t *testing.T) {
+	// 两个流式分支:各推一个 token 后给终态。
+	a := &agent.Runner{Name: "a", Client: &streamScriptClient{streams: [][]llm.Chunk{{{Delta: "A1"}, {Done: true}}}}}
+	b := &agent.Runner{Name: "b", Client: &streamScriptClient{streams: [][]llm.Chunk{{{Delta: "B1"}, {Done: true}}}}}
+	p := &agent.Parallel{Agents: []agent.Agent{a, b}}
+
+	var finals []agent.Event
+	tokens := map[string]int{}
+	for ev := range p.RunStream(context.Background(), llm.Request{Model: "m"}) {
+		switch ev.Type {
+		case agent.EventError:
+			t.Fatalf("unexpected error: %v", ev.Err)
+		case agent.EventToken:
+			tokens[ev.AgentName]++
+		case agent.EventFinal:
+			finals = append(finals, ev)
+		}
+	}
+	if len(finals) != 1 {
+		t.Fatalf("应恰好一条终态 EventFinal, got %d", len(finals))
+	}
+	// 合并结果应含两分支的内容(顺序稳定:a 在前)。
+	if !strings.Contains(finals[0].Response.Content, "A1") || !strings.Contains(finals[0].Response.Content, "B1") {
+		t.Fatalf("合并结果应含两分支内容: %q", finals[0].Response.Content)
+	}
+	if tokens["a"] == 0 || tokens["b"] == 0 {
+		t.Fatalf("两分支的 token 事件都应透传: %v", tokens)
+	}
+}


### PR DESCRIPTION
… compaction + message merge

Adds Parallel (concurrent multi-agent fan-out with pluggable Combiner) to round out the Chain/Team/BestOfN/Parallel composition family. Adds three opt-in, deterministic robustness switches on Runner: RepairToolArgs (best- effort JSON repair for near-valid tool_call arguments), Compactor (per-turn token-bounded projection of tool-result history to bound context growth), and MergeConsecutive/MergeMessagesHook (merge adjacent same-role messages for providers requiring strict role alternation).